### PR TITLE
Fixed setting value of a multi-select would only set first element

### DIFF
--- a/src/select2.component.ts
+++ b/src/select2.component.ts
@@ -54,10 +54,11 @@ export class Select2Component extends CustomInputComponent
 
   setSelect2Value() {
     if (this.value instanceof Array) {
-      this.select2.select2('val', [...this.value]);
+      this.select2.val([...this.value]);
     } else {
-      this.select2.select2('val', [this.value]);
+      this.select2.val([this.value]);
     }
+    this.select2.trigger('change');
   }
 
   ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
Updated to match the current examples for "setting multi-value" shown here: https://select2.org/programmatic-control/methods